### PR TITLE
Add handler for JSON data type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.idea/
 /.vagrant/
 /vendor/
+/build/
 composer.phar
 phpunit.xml
 Vagrantfile

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "php" : "7.2 - 7.4",
     "ext-pdo" : "*",
     "ext-mysqlnd" : "*",
-    "milesasylum/schnoop-schema": "^0.3"
+    "milesasylum/schnoop-schema": "^0.3.1"
   },
   "require-dev": {
     "php-coveralls/php-coveralls": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,23 +4,24 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7223199e59880c501556144d0611e17f",
+    "content-hash": "d75933bdc14c76aed1a2784a3426d3bd",
     "packages": [
         {
             "name": "milesasylum/schnoop-schema",
-            "version": "v0.3.0",
+            "version": "v0.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/courtney-miles/schnoop-schema.git",
-                "reference": "f940b28e90358cb06e895066da00258d243ddd3c"
+                "reference": "87e2acb9869732b0e6f8f74adb4a66dcb604734b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/courtney-miles/schnoop-schema/zipball/f940b28e90358cb06e895066da00258d243ddd3c",
-                "reference": "f940b28e90358cb06e895066da00258d243ddd3c",
+                "url": "https://api.github.com/repos/courtney-miles/schnoop-schema/zipball/87e2acb9869732b0e6f8f74adb4a66dcb604734b",
+                "reference": "87e2acb9869732b0e6f8f74adb4a66dcb604734b",
                 "shasum": ""
             },
             "require": {
+                "ext-json": "*",
                 "php": "7.2 - 7.4"
             },
             "require-dev": {
@@ -55,9 +56,9 @@
             ],
             "support": {
                 "issues": "https://github.com/courtney-miles/schnoop-schema/issues",
-                "source": "https://github.com/courtney-miles/schnoop-schema/tree/v0.3.0"
+                "source": "https://github.com/courtney-miles/schnoop-schema/tree/v0.3.1"
             },
-            "time": "2021-04-21T22:04:11+00:00"
+            "time": "2022-01-26T08:37:25+00:00"
         }
     ],
     "packages-dev": [
@@ -3391,5 +3392,5 @@
         "ext-mysqlnd": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/src/SchemaFactory/MySQL/DataType/DataTypeFactory.php
+++ b/src/SchemaFactory/MySQL/DataType/DataTypeFactory.php
@@ -2,37 +2,8 @@
 
 namespace MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType;
 
+use InvalidArgumentException;
 use MilesAsylum\Schnoop\SchemaFactory\Exception\FactoryException;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\BigIntTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\BinaryTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\BitTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\BlobTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\CharTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\DataTypeFactoryInterface;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\DateTimeTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\DateTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\DecimalTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\DoubleTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\EnumTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\FloatTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\IntTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\LongBlobTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\LongTextTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\MediumBlobTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\MediumIntTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\MediumTextTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\SetTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\SmallIntTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\TextTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\TimestampTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\TimeTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\TinyBlobTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\TinyIntTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\TinyTextTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\VarBinaryTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\VarCharTypeFactory;
-use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\YearTypeFactory;
-use MilesAsylum\SchnoopSchema\MySQL\DataType\DataTypeInterface;
 
 class DataTypeFactory implements DataTypeFactoryInterface
 {
@@ -92,6 +63,10 @@ class DataTypeFactory implements DataTypeFactoryInterface
      */
     public function getFactoryHandlerForType($typeName)
     {
+        if (!isset($this->factoryTypeHandlers[$typeName])) {
+            throw new InvalidArgumentException("A handler does not exist for type $typeName.");
+        }
+
         return $this->factoryTypeHandlers[$typeName];
     }
 
@@ -138,6 +113,8 @@ class DataTypeFactory implements DataTypeFactoryInterface
         // Option type mappers.
         $dataTypeFactory->addFactoryTypeHandler('enum', new EnumTypeFactory());
         $dataTypeFactory->addFactoryTypeHandler('set', new SetTypeFactory());
+        // Other type mappers.
+        $dataTypeFactory->addFactoryTypeHandler('json', new JsonTypeFactory());
 
         return $dataTypeFactory;
     }

--- a/src/SchemaFactory/MySQL/DataType/JsonTypeFactory.php
+++ b/src/SchemaFactory/MySQL/DataType/JsonTypeFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType;
+
+use MilesAsylum\SchnoopSchema\MySQL\DataType\JsonType;
+
+class JsonTypeFactory implements DataTypeFactoryInterface
+{
+    public function createType($typeStr, $collation = null)
+    {
+        if (!$this->doRecognise($typeStr)) {
+            return false;
+        }
+
+        return new JsonType();
+    }
+
+    public function doRecognise($typeStr)
+    {
+        return preg_match('/^json$/i', $typeStr) === 1;
+    }
+}

--- a/tests/Schnoop/SchemaFactory/MySQL/DataType/DataTypeFactoryTest.php
+++ b/tests/Schnoop/SchemaFactory/MySQL/DataType/DataTypeFactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace MilesAsylum\Schnoop\Tests\Schnoop\SchemaFactory\MySQL\DataType;
 
+use InvalidArgumentException;
 use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\BigIntTypeFactory;
 use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\BinaryTypeFactory;
 use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\BitTypeFactory;
@@ -16,6 +17,7 @@ use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\DoubleTypeFactory;
 use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\EnumTypeFactory;
 use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\FloatTypeFactory;
 use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\IntTypeFactory;
+use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\JsonTypeFactory;
 use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\LongBlobTypeFactory;
 use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\LongTextTypeFactory;
 use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\MediumBlobTypeFactory;
@@ -83,6 +85,14 @@ class DataTypeFactoryTest extends TestCase
             $this->mockFactoryHandler,
             $this->dataTypeFactory->getFactoryHandlerForType($typeName)
         );
+    }
+
+    public function testExceptionOnGetUndefinedTypeHandler(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $sut = new DataTypeFactory();
+        $sut->getFactoryHandlerForType('bogus');
     }
 
     public function testCreateType()
@@ -193,6 +203,7 @@ class DataTypeFactoryTest extends TestCase
             'text' => ['text', TextTypeFactory::class],
             'mediumtext' => ['mediumtext', MediumTextTypeFactory::class],
             'longtext' => ['longtext', LongTextTypeFactory::class],
+            'json' => ['json', JsonTypeFactory::class],
             // Option type mappers.
             'enum' => ['enum', EnumTypeFactory::class],
             'set' => ['set', SetTypeFactory::class],

--- a/tests/Schnoop/SchemaFactory/MySQL/DataType/JsonTypeFactoryTest.php
+++ b/tests/Schnoop/SchemaFactory/MySQL/DataType/JsonTypeFactoryTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MilesAsylum\Schnoop\Tests\Schnoop\SchemaFactory\MySQL\DataType;
+
+use MilesAsylum\Schnoop\PHPUnit\Framework\SchnoopTestCase;
+use MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\JsonTypeFactory;
+use MilesAsylum\SchnoopSchema\MySQL\DataType\JsonType;
+
+/**
+ * @covers \MilesAsylum\Schnoop\SchemaFactory\MySQL\DataType\JsonTypeFactory
+ */
+class JsonTypeFactoryTest extends SchnoopTestCase
+{
+    /**
+     * @dataProvider provideJsonTypeStrings
+     */
+    public function testDoRecogniseType(string $typeString): void
+    {
+        $sut = new JsonTypeFactory();
+
+        self::assertTrue($sut->doRecognise($typeString));
+    }
+
+    public function provideJsonTypeStrings(): array
+    {
+        return [
+            ['json'],
+            ['JSON'],
+        ];
+    }
+
+    public function testDoNotRecogniseType(): void
+    {
+        $sut = new JsonTypeFactory();
+
+        self::assertFalse($sut->doRecognise('not_json'));
+    }
+
+    /**
+     * @dataProvider provideTypeStrings
+     */
+    public function testCreateType(string $typeString): void
+    {
+        $sut = new JsonTypeFactory();
+
+        self::assertInstanceOf(
+            JsonType::class,
+            $sut->createType($typeString)
+        );
+    }
+
+    public function provideTypeStrings(): array
+    {
+        return [
+            ['JSON'],
+            ['json'],
+        ];
+    }
+
+    public function testCreateTypeWrongString(): void
+    {
+        $sut = new JsonTypeFactory();
+
+        self::assertFalse($sut->createType('BOGUS'));
+    }
+}


### PR DESCRIPTION
* **Issue:** #9 
* **What:** Add support for handing columns of type [JSON](https://dev.mysql.com/doc/refman/5.7/en/json.html)
* **Why:** JSON was added to MySQL in version 5.7 and this package will error if it sees JSON column.