### PR TITLE
Return NULL on get table not found.

### DIFF
--- a/src/SchemaFactory/MySQL/Table/TableFactory.php
+++ b/src/SchemaFactory/MySQL/Table/TableFactory.php
@@ -35,7 +35,9 @@ SQL;
      */
     public function fetch($tableName, $databaseName)
     {
-        return $this->createFromRaw($this->fetchRaw($tableName, $databaseName), $databaseName);
+        $rawTable = $this->fetchRaw($tableName, $databaseName);
+
+        return $rawTable !== null ? $this->createFromRaw($rawTable, $databaseName) : null;
     }
 
     /**


### PR DESCRIPTION
* **Issue:** #3 
* **What:** Fixes Type error when getting a table that does not exist
* **Why:** It is intended to return NULL